### PR TITLE
Improve Electron rebuild error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ npm install --runtime=electron --target=30.0.0
 
 Le script `rebuild:electron` appelle `cmake-js rebuild --runtime=electron --runtimeVersion=<version>`. Pendant `npm install`, si vous passez `--runtime=electron --target=<version>`, le script `postinstall` détecte Electron et reconstruit automatiquement.
 
+En cas d'échec, `npm run rebuild:electron` renvoie désormais un code de sortie non nul et affiche les erreurs de `cmake-js` pour faciliter le diagnostic. Sur les systèmes POSIX où `npx` est indisponible, le script bascule automatiquement sur le binaire `cmake-js` local installé avec le projet.
+
 2) Chargement du binaire dans Electron
 
 - Le chargement utilise le paquet `bindings` pour localiser `soem_addon.node`, compatible avec les bundles Electron et `asarUnpack`.

--- a/scripts/rebuild-electron.js
+++ b/scripts/rebuild-electron.js
@@ -11,7 +11,7 @@ const path = require('node:path');
 
 const version = process.argv[2] || process.env.ELECTRON_VERSION || process.env.npm_config_target;
 if (!version) {
-    console.error('[soem-node] Veuillez fournir la version d\'Electron (ex: 30.0.0).');
+    console.error("[soem-node] Veuillez fournir la version d'Electron (ex: 30.0.0).");
     console.error('  Ex: node scripts/rebuild-electron.js 30.0.0');
     process.exit(1);
 }
@@ -19,13 +19,80 @@ if (!version) {
 console.log(`[soem-node] Rebuild pour Electron v${version}...`);
 
 const isWin = process.platform === 'win32';
-const cmakeJs = isWin
-    ? path.join(__dirname, '..', 'node_modules', '.bin', 'cmake-js.cmd')
-    : 'npx';
+const sharedArgs = ['--runtime=electron', `--runtimeVersion=${version}`, '--loglevel=verbose'];
+const localBinary = path.join(
+    __dirname,
+    '..',
+    'node_modules',
+    '.bin',
+    isWin ? 'cmake-js.cmd' : 'cmake-js',
+);
 
-const args = isWin
-    ? ['rebuild', '--runtime=electron', `--runtimeVersion=${version}`, '--loglevel=verbose']
-    : ['cmake-js', 'rebuild', '--runtime=electron', `--runtimeVersion=${version}`, '--loglevel=verbose'];
+const spawnOptions = {
+    stdio: 'pipe',
+    shell: isWin,
+};
 
-const res = spawnSync(cmakeJs, args, { stdio: 'inherit', shell: isWin });
-process.exit(res.status || 0);
+const pipeResult = (result) => {
+    if (result.stdout?.length) {
+        process.stdout.write(result.stdout);
+    }
+    if (result.stderr?.length) {
+        process.stderr.write(result.stderr);
+    }
+};
+
+const formatCommand = (command, args) => [command, ...args].join(' ');
+
+const handleFailure = (commandLabel, result) => {
+    let errorMessage = `[soem-node] Échec de l'exécution de ${commandLabel}.`;
+    if (result.error) {
+        errorMessage += ` ${result.error.message}`;
+    } else if (typeof result.status === 'number') {
+        errorMessage += ` Code de sortie: ${result.status}.`;
+    } else if (result.signal) {
+        errorMessage += ` Signal reçu: ${result.signal}.`;
+    }
+
+    const stderrOutput = result.stderr?.toString();
+    if (stderrOutput) {
+        errorMessage += `\n--- stderr ---\n${stderrOutput.trimEnd()}`;
+    }
+
+    console.error(errorMessage);
+    process.exit(result.status || 1);
+};
+
+const execute = (command, args) => {
+    const result = spawnSync(command, args, spawnOptions);
+    pipeResult(result);
+    return result;
+};
+
+if (isWin) {
+    const args = ['rebuild', ...sharedArgs];
+    const result = execute(localBinary, args);
+    if (result.error || result.status !== 0) {
+        handleFailure(formatCommand(localBinary, args), result);
+    }
+    process.exit(0);
+}
+
+const npxArgs = ['cmake-js', 'rebuild', ...sharedArgs];
+let result = execute('npx', npxArgs);
+
+if (result.error?.code === 'ENOENT') {
+    console.warn("[soem-node] 'npx' est indisponible, tentative avec le binaire local cmake-js.");
+    const directArgs = ['rebuild', ...sharedArgs];
+    result = execute(localBinary, directArgs);
+    if (result.error || result.status !== 0) {
+        handleFailure(formatCommand(localBinary, directArgs), result);
+    }
+    process.exit(0);
+}
+
+if (result.error || result.status !== 0) {
+    handleFailure(formatCommand('npx', npxArgs), result);
+}
+
+process.exit(0);


### PR DESCRIPTION
## Summary
- ensure the Electron rebuild script reports non-zero exit codes with detailed error output
- fall back to the local cmake-js binary when npx is missing on POSIX hosts
- document the stricter failure reporting for developers in the Electron README section

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd69fef21c83248d77943bb7a3b2ea